### PR TITLE
Add startup LED blink pattern

### DIFF
--- a/ESP8266-VictronHA.ino
+++ b/ESP8266-VictronHA.ino
@@ -135,6 +135,21 @@ void processVictronData(String key, String value) {
     }
 }
 
+void startupBlink() {
+    for (int i = 0; i < 3; i++) {
+        digitalWrite(LED_PIN, LOW);
+        delay(200);
+        digitalWrite(LED_PIN, HIGH);
+        delay(200);
+    }
+    for (int i = 0; i < 3; i++) {
+        digitalWrite(LED_PIN, LOW);
+        delay(600);
+        digitalWrite(LED_PIN, HIGH);
+        delay(200);
+    }
+}
+
 void setup() {
     display.begin(i2c_Address, true);
     display.setTextSize(1);
@@ -150,6 +165,7 @@ void setup() {
 
     pinMode(LED_PIN, OUTPUT);
     digitalWrite(LED_PIN, HIGH);
+    startupBlink();
     WiFi.persistent(false);
     WiFi.setAutoReconnect(true);
 


### PR DESCRIPTION
## Summary
- Add startupBlink function to signal board initialization with 3 short and 3 long LED flashes
- Invoke startup blink sequence before WiFi setup on WeMos D1 R1

## Testing
- `arduino-cli compile --fqbn esp8266:esp8266:d1 ESP8266-VictronHA.ino`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a4704f48326a8f1c293c91c0b1a