### PR TITLE
Publish Victron metrics on individual MQTT topics

### DIFF
--- a/ESP8266-VictronHA.ino
+++ b/ESP8266-VictronHA.ino
@@ -155,13 +155,13 @@ void processVictronData(String key, String value) {
     } else if (key == "SOC") {
         soc = "SOC: " + String(value.toFloat() / 10, 1) + "%";
     }
-    
+
     scrollText = voltage + "  |  " + current + "  |  " + soc;
     activityIndicator = !activityIndicator;
 
     if (mqttClient.connected()) {
-        String payload = voltage + "," + current + "," + soc;
-        mqttClient.publish(MQTT_TOPIC, payload.c_str());
+        String topic = String(MQTT_TOPIC) + "/" + key;
+        mqttClient.publish(topic.c_str(), value.c_str());
         lastDataSent = millis();
     }
 }


### PR DESCRIPTION
## Summary
- Send each Victron key/value pair to its own MQTT subtopic so Home Assistant receives raw values

## Testing
- `bash CodexEnvironment.txt` *(fails: HTTP 403 from proxy)*
- `arduino-cli compile --fqbn esp8266:esp8266:nodemcuv2 ESP8266-VictronHA.ino` *(hangs due to missing network access; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ebeb1a88326865e0b3e84d012ba