### PR TITLE
docs: document WiFi resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ state of the device:
 | 4       | Data recently published  |
 
 Each sequence repeats with a short pause between groups.
+
+## WiFi resilience
+
+The sketch monitors the wireless connection and enables automatic
+reconnection. If WiFi drops, the main loop triggers a disconnect and
+retries `connectWiFi()` for up to 10 seconds per attempt until the
+network is restored, allowing MQTT publishing to resume without manual
+intervention.


### PR DESCRIPTION
## Summary
- explain WiFi auto-reconnect behavior in README

## Testing
- `bash CodexEnvironment.txt` *(fails: 403 from proxy)*
- `arduino-cli compile --fqbn esp8266:esp8266:nodemcuv2 ESP8266-VictronHA.ino`

------
https://chatgpt.com/codex/tasks/task_e_68bc615b2d4c832689696f0e54c52558