### PR TITLE
Update README with build instructions + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dylan Jones
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+FQBN=esp8266:esp8266:nodemcuv2
+SKETCH=ESP8266-VictronHA.ino
+
+.PHONY: setup build clean
+
+setup:
+	bash CodexEnvironment.txt
+
+build:
+	arduino-cli compile --fqbn $(FQBN) $(SKETCH)
+
+clean:
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -15,16 +15,24 @@ your environment before compiling the sketch.
 
 This project uses [arduino-cli](https://arduino.github.io/arduino-cli/latest/) to compile for the ESP8266.
 
-1. Install dependencies and required libraries by running the setup script:
+1. Run the configuration script to verify required tools and libraries:
 
    ```bash
-   bash CodexEnvironment.txt
+   ./configure
    ```
 
-2. Compile the sketch for NodeMCU v2:
+   The script reports any missing dependencies and hints on how to install them.
+
+2. (Optional) Install the toolchain and libraries using the provided setup target:
 
    ```bash
-   arduino-cli compile --fqbn esp8266:esp8266:nodemcuv2 ESP8266-VictronHA.ino
+   make setup
+   ```
+
+3. Compile the sketch for NodeMCU v2:
+
+   ```bash
+   make build
    ```
 
 The sketch file `ESP8266-VictronHA.ino` must reside in a folder with the same name to compile correctly.
@@ -50,3 +58,7 @@ reconnection. If WiFi drops, the main loop triggers a disconnect and
 retries `connectWiFi()` for up to 10 seconds per attempt until the
 network is restored, allowing MQTT publishing to resume without manual
 intervention.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/configure
+++ b/configure
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -e
+missing=0
+
+check_tool() {
+  local tool="$1"
+  local hint="$2"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Missing required tool: $tool"
+    echo "  Hint: $hint"
+    missing=1
+  else
+    echo "Found $tool"
+  fi
+}
+
+check_lib() {
+  local lib="$1"
+  if ! arduino-cli lib list 2>/dev/null | grep -Fq "$lib"; then
+    echo "Missing Arduino library: $lib"
+    echo "  Hint: arduino-cli lib install \"$lib\""
+    missing=1
+  else
+    echo "Found Arduino library: $lib"
+  fi
+}
+
+check_tool arduino-cli "Install from https://arduino.github.io/arduino-cli/latest/"
+check_tool git "Install with: sudo apt-get install git"
+check_tool python3 "Install with: sudo apt-get install python3"
+
+if command -v arduino-cli >/dev/null 2>&1; then
+  if ! arduino-cli core list 2>/dev/null | grep -q '^esp8266:esp8266'; then
+    echo "Missing ESP8266 board core"
+    echo "  Hint: arduino-cli core install esp8266:esp8266"
+    missing=1
+  fi
+  check_lib "Adafruit GFX Library"
+  check_lib "ArduinoJson"
+  check_lib "Adafruit SH110X"
+  check_lib "SimpleRotary"
+  check_lib "PubSubClient"
+fi
+
+if [ $missing -ne 0 ]; then
+  echo "Configuration check failed. Please install missing dependencies."
+  exit 1
+else
+  echo "All dependencies satisfied."
+fi


### PR DESCRIPTION
## Summary
- add MIT license
- provide Makefile and configure script for setup and builds
- document new build steps in README

## Testing
- `./configure`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68bc895a03608326bf650b17042f434e