### PR TITLE
Fix setup script and clarify build instructions

### DIFF
--- a/CodexEnvironment.txt
+++ b/CodexEnvironment.txt
@@ -18,10 +18,17 @@ echo "HTTPS_PROXY=${HTTPS_PROXY:-<unset>}"
 echo "NO_PROXY=${NO_PROXY}"
 
 echo "==> Using signed Ubuntu mirror"
-sed -i \
-  -e 's|http://archive.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
-  -e 's|http://security.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
-  /etc/apt/sources.list.d/ubuntu.sources
+if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+  sed -i \
+    -e 's|http://archive.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
+    -e 's|http://security.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list.d/ubuntu.sources
+elif [ -f /etc/apt/sources.list ]; then
+  sed -i \
+    -e 's|http://archive.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
+    -e 's|http://security.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list
+fi
 
 # Drop unsigned or unreachable sources such as the LLVM repo
 rm -f /etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_noble_-noble.list

--- a/CodexEnvironment.txt
+++ b/CodexEnvironment.txt
@@ -18,16 +18,20 @@ echo "HTTPS_PROXY=${HTTPS_PROXY:-<unset>}"
 echo "NO_PROXY=${NO_PROXY}"
 
 echo "==> Using signed Ubuntu mirror"
+sources_file=""
 if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-  sed -i \
-    -e 's|http://archive.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
-    -e 's|http://security.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
-    /etc/apt/sources.list.d/ubuntu.sources
+  sources_file=/etc/apt/sources.list.d/ubuntu.sources
 elif [ -f /etc/apt/sources.list ]; then
+  sources_file=/etc/apt/sources.list
+fi
+
+if [ -n "$sources_file" ]; then
   sed -i \
     -e 's|http://archive.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
     -e 's|http://security.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
-    /etc/apt/sources.list
+    "$sources_file"
+else
+  echo "No apt sources file found, skipping mirror configuration"
 fi
 
 # Drop unsigned or unreachable sources such as the LLVM repo

--- a/CodexEnvironment.txt
+++ b/CodexEnvironment.txt
@@ -18,33 +18,37 @@ echo "HTTPS_PROXY=${HTTPS_PROXY:-<unset>}"
 echo "NO_PROXY=${NO_PROXY}"
 
 echo "==> Using signed Ubuntu mirror"
-sources_file=""
-if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-  sources_file=/etc/apt/sources.list.d/ubuntu.sources
-elif [ -f /etc/apt/sources.list ]; then
-  sources_file=/etc/apt/sources.list
-fi
+if command -v apt-get >/dev/null 2>&1; then
+  sources_file=""
+  if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+    sources_file=/etc/apt/sources.list.d/ubuntu.sources
+  elif [ -f /etc/apt/sources.list ]; then
+    sources_file=/etc/apt/sources.list
+  fi
 
-if [ -n "$sources_file" ]; then
-  sed -i \
-    -e 's|http://archive.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
-    -e 's|http://security.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
-    "$sources_file"
+  if [ -f "$sources_file" ]; then
+    sed -i \
+      -e 's|http://archive.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
+      -e 's|http://security.ubuntu.com/ubuntu/|https://mirrors.kernel.org/ubuntu/|g' \
+      "$sources_file"
+  else
+    echo "No apt sources file found, skipping mirror configuration"
+  fi
+
+  # Drop unsigned or unreachable sources such as the LLVM repo
+  rm -f /etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_noble_-noble.list
+
+  echo "==> Base packages"
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    curl ca-certificates git python3 tar xz-utils
+
+  # --- Prefer IPv4 to avoid IPv6 'network is unreachable' ---
+  if ! grep -q '^precedence ::ffff:0:0/96 100' /etc/gai.conf 2>/dev/null; then
+    echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
+  fi
 else
-  echo "No apt sources file found, skipping mirror configuration"
-fi
-
-# Drop unsigned or unreachable sources such as the LLVM repo
-rm -f /etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_noble_-noble.list
-
-echo "==> Base packages"
-apt-get update
-apt-get install -y --no-install-recommends \
-  curl ca-certificates git python3 tar xz-utils
-
-# --- Prefer IPv4 to avoid IPv6 'network is unreachable' ---
-if ! grep -q '^precedence ::ffff:0:0/96 100' /etc/gai.conf 2>/dev/null; then
-  echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
+  echo "apt-get not found; skipping system package installation"
 fi
 
 # --- Helper: retry with backoff ---

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 FQBN=esp8266:esp8266:nodemcuv2
 SKETCH=ESP8266-VictronHA.ino
 BUILD_DIR=build
+BIN=$(BUILD_DIR)/$(notdir $(SKETCH)).bin
 
 .PHONY: setup build clean
 
@@ -10,6 +11,7 @@ setup:
 
 build:
 	arduino-cli compile --fqbn $(FQBN) --output-dir $(BUILD_DIR) $(SKETCH)
+	@echo "Firmware binary: $(BIN)"
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 FQBN=esp8266:esp8266:nodemcuv2
 SKETCH=ESP8266-VictronHA.ino
+BUILD_DIR=build
 
 .PHONY: setup build clean
 
@@ -7,7 +8,7 @@ setup:
 	bash CodexEnvironment.txt
 
 build:
-	arduino-cli compile --fqbn $(FQBN) $(SKETCH)
+	arduino-cli compile --fqbn $(FQBN) --output-dir $(BUILD_DIR) $(SKETCH)
 
 clean:
-	rm -rf build
+	rm -rf $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.DEFAULT_GOAL := build
 FQBN=esp8266:esp8266:nodemcuv2
 SKETCH=ESP8266-VictronHA.ino
 BUILD_DIR=build

--- a/README.md
+++ b/README.md
@@ -29,11 +29,17 @@ This project uses [arduino-cli](https://arduino.github.io/arduino-cli/latest/) t
    make setup
    ```
 
+   The script configures a local Arduino toolchain. It now detects
+   both `/etc/apt/sources.list` and the newer `/etc/apt/sources.list.d/ubuntu.sources`
+   so it can run on a wider range of systems.
+
 3. Compile the sketch for NodeMCU v2:
 
    ```bash
    make build
    ```
+
+   The build artifacts will be placed in the `build/` directory.
 
 The sketch file `ESP8266-VictronHA.ino` must reside in a folder with the same name to compile correctly.
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ This project uses [arduino-cli](https://arduino.github.io/arduino-cli/latest/) t
    make setup
    ```
 
-   The script configures a local Arduino toolchain. It now detects
-   both `/etc/apt/sources.list` and the newer `/etc/apt/sources.list.d/ubuntu.sources`
-   and will skip mirror configuration if neither file exists.
+   The script configures a local Arduino toolchain. It detects both
+   `/etc/apt/sources.list` and the newer `/etc/apt/sources.list.d/ubuntu.sources`
+   and skips mirror configuration or package installation if `apt-get` is not
+   available on your system.
 
 3. Compile the sketch for NodeMCU v2 (default make target):
 
@@ -39,7 +40,8 @@ This project uses [arduino-cli](https://arduino.github.io/arduino-cli/latest/) t
    make       # or: make build
    ```
 
-   The build artifacts will be placed in the `build/` directory.
+   The firmware binary will be placed at
+   `build/ESP8266-VictronHA.ino.bin`.
 
 The sketch file `ESP8266-VictronHA.ino` must reside in a folder with the same name to compile correctly.
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ This project uses [arduino-cli](https://arduino.github.io/arduino-cli/latest/) t
 
    The script configures a local Arduino toolchain. It now detects
    both `/etc/apt/sources.list` and the newer `/etc/apt/sources.list.d/ubuntu.sources`
-   so it can run on a wider range of systems.
+   and will skip mirror configuration if neither file exists.
 
-3. Compile the sketch for NodeMCU v2:
+3. Compile the sketch for NodeMCU v2 (default make target):
 
    ```bash
-   make build
+   make       # or: make build
    ```
 
    The build artifacts will be placed in the `build/` directory.


### PR DESCRIPTION
## Summary
- handle missing `/etc/apt/sources.list` variants in setup script
- compile build output to `build/` directory with new Makefile target
- document setup script behavior and build output location

## Testing
- ⚠️ `make setup` (fails: 403 Forbidden from proxy)
- ✅ `make build`
- ✅ `./configure`

------
https://chatgpt.com/codex/tasks/task_e_68bc8f63e2108326b899b2b224b54122